### PR TITLE
Fix Safari bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:latest AS build
+FROM node:alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx AS deploy
+FROM nginx:alpine AS deploy
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -41,7 +41,7 @@ export function getBearerToken() {
         if (bearerToken !== null && bearerToken !== undefined) {
             resolve(bearerToken);
         }
-        // If that's missing, get signInToken from localStorage or the URL query parameters
+        // If that's missing, get signInToken from the URL query parameters
         // and then POST that to /signin/ to get a Bearer token
         const signInToken = getSignInToken();
         if (signInToken !== null && signInToken !== undefined) {
@@ -55,7 +55,6 @@ export function getBearerToken() {
 const handlers = {
     201: resp => resp.json(),
     500: () => {
-        localStorage.removeItem("signInToken");
         localStorage.removeItem("bearerToken");
     }
 };
@@ -74,18 +73,16 @@ export function fetchBearerTokenAndSave(signInToken) {
 }
 
 function getSignInToken() {
-    let signInToken = localStorage.getItem("signInToken");
-    if (signInToken === null) {
-        signInToken = getSignInTokenFromURL(window.location.search);
-        if (
-            signInToken !== null &&
-            isString(signInToken) &&
-            signInToken.length > 0
-        ) {
-            localStorage.setItem("signInToken", signInToken);
-        }
+    let signInToken = getSignInTokenFromURL(window.location.search);
+    if (
+        signInToken !== null &&
+        isString(signInToken) &&
+        signInToken.length > 0
+    ) {
+        return signInToken;
+    } else {
+        return null;
     }
-    return signInToken;
 }
 
 function getSignInTokenFromURL(search) {

--- a/src/components/HighlightUnassigned.js
+++ b/src/components/HighlightUnassigned.js
@@ -10,7 +10,7 @@ export function toggle(label, checked, onChange) {
             <input
                 type="checkbox"
                 ?checked="${checked}"
-                @input="${e => onChange(e.target.checked)}"
+                @change="${e => onChange(e.target.checked)}"
             />
             ${label}
         </label>

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -9,50 +9,42 @@ const tabs = (tabs, activeTab, onChange) => {
     }
     return html`
         <ul class="tabs">
-            ${
-                tabs.map(
-                    tab => html`
-                        <li>
-                            <input
-                                type="radio"
-                                name="tabs"
-                                value="${tab.id}"
-                                ?checked="${tab.id == activeTab}"
-                                @input="${() => onChange({ id: tab.id })}"
-                            />
-                            <div class="tabs__tab">${tab.name}</div>
-                        </li>
-                    `
-                )
-            }
+            ${tabs.map(
+                tab => html`
+                    <li>
+                        <input
+                            type="radio"
+                            name="tabs"
+                            value="${tab.id}"
+                            ?checked="${tab.id == activeTab}"
+                            @change="${() => onChange({ id: tab.id })}"
+                        />
+                        <div class="tabs__tab">${tab.name}</div>
+                    </li>
+                `
+            )}
         </ul>
     `;
 };
 
 export default function Tabs(tabComponents, state, dispatch) {
     return html`
-        ${
-            tabs(tabComponents, state.tabs.activeTab, info =>
-                dispatch(actions.changeTab(info))
-            )
-        }
-        ${
-            repeat(
-                tabComponents,
-                tab => tab.id,
-                tab => html`
-                    <div
-                        class=${
-                            classMap({
-                                tab__body: true,
-                                active: tab.id === state.tabs.activeTab
-                            })
-                        }
-                    >
-                        ${tab.render(state, dispatch)}
-                    </div>
-                `
-            )
-        }
+        ${tabs(tabComponents, state.tabs.activeTab, info =>
+            dispatch(actions.changeTab(info))
+        )}
+        ${repeat(
+            tabComponents,
+            tab => tab.id,
+            tab => html`
+                <div
+                    class=${classMap({
+                        tab__body: true,
+                        active: tab.id === state.tabs.activeTab
+                    })}
+                >
+                    ${tab.render(state, dispatch)}
+                </div>
+            `
+        )}
     `;
 }

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -6,7 +6,7 @@ export function toggle(label, checked, onChange) {
             <input
                 type="checkbox"
                 ?checked="${checked}"
-                @input="${e => onChange(e.target.checked)}"
+                @change="${e => onChange(e.target.checked)}"
             />
             ${label}
         </label>

--- a/src/components/Toolbar/BrushColorPicker.js
+++ b/src/components/Toolbar/BrushColorPicker.js
@@ -3,25 +3,23 @@ import { html } from "lit-html";
 export default (colors, onInput, activeColor) => html`
     <legend>Color</legend>
     <div class="icon-list color-list">
-        ${
-            colors.map(
-                color => html`
-                    <div class="icon-list__item color-list__item">
-                        <input
-                            type="radio"
-                            id="brush-color__${color.id}"
-                            name="brush-color"
-                            value="${color.id}"
-                            ?checked="${color.id === activeColor}"
-                            @input="${onInput}"
-                        />
-                        <div
-                            class="icon-list__item__radio"
-                            style="background: ${color.color}"
-                        ></div>
-                    </div>
-                `
-            )
-        }
+        ${colors.map(
+            color => html`
+                <div class="icon-list__item color-list__item">
+                    <input
+                        type="radio"
+                        id="brush-color__${color.id}"
+                        name="brush-color"
+                        value="${color.id}"
+                        ?checked="${color.id === activeColor}"
+                        @change="${onInput}"
+                    />
+                    <div
+                        class="icon-list__item__radio"
+                        style="background: ${color.color}"
+                    ></div>
+                </div>
+            `
+        )}
     </div>
 `;

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -79,7 +79,7 @@ const BrushLock = (locked, toggle) => html`
             name="brush-lock"
             value="brush-lock"
             ?checked=${locked}
-            @input=${toggle}
+            @change=${toggle}
         />
         Lock already-painted units
     </label>

--- a/src/components/Toolbar/Tool.js
+++ b/src/components/Toolbar/Tool.js
@@ -15,18 +15,19 @@ export default class Tool {
     }
     render(selectTool) {
         return html`
-    <div class="icon-list__item" title="${this.name}">
-    <label>${this.name}</label>
-    <input
-        type="radio"
-        id="tool-${this.id}"
-        name="tool"
-        value="${this.id}"
-        @input=${() => selectTool(this.id)}
-        ?checked=${this.active}
-    >
-    <div class="icon-list__item__radio"></div>
-    ${this.icon}
-    </div>`;
+            <div class="icon-list__item" title="${this.name}">
+                <label>${this.name}</label>
+                <input
+                    type="radio"
+                    id="tool-${this.id}"
+                    name="tool"
+                    value="${this.id}"
+                    @change=${() => selectTool(this.id)}
+                    ?checked=${this.active}
+                />
+                <div class="icon-list__item__radio"></div>
+                ${this.icon}
+            </div>
+        `;
     }
 }


### PR DESCRIPTION
Most of our UI elements weren't working properly in Safari because Safari has a bug where `input` events don't fire for checkboxes or radio buttons. (See https://caniuse.com/#feat=input-event and https://bugs.webkit.org/show_bug.cgi?id=149398 ).

This PR replaces `@input` lit-html event handlers with `@change` ones. That should fix it. Everything still works in the expected way in Firefox, and we can test it on Safari soon.

This PR also uses alpine base images for the Dockerfile, but that only affects the "staging" deployment pipeline.