### PR TITLE
Fix Wisconsin "blocks" -> "wards"

### DIFF
--- a/assets/data/response.json
+++ b/assets/data/response.json
@@ -3687,7 +3687,7 @@
     {
         "id": "wisconsin_12_16",
         "name": "Wisconsin",
-        "unitType": "Blocks",
+        "unitType": "Wards",
         "tilesets": [
             {
                 "type": "fill",

--- a/sass/components/_toolbar.scss
+++ b/sass/components/_toolbar.scss
@@ -73,7 +73,7 @@ legend {
 .tool-options.active {
     opacity: 1;
     border-top: solid 1px #aaa;
-    max-height: 100vh;
+    max-height: 20rem;
 }
 
 .tool-option-container {

--- a/src/components/Landmark.js
+++ b/src/components/Landmark.js
@@ -12,7 +12,7 @@ export function LandmarkInfo(features) {
                 <h4 class="tooltip-title">${feature.properties.name}</h4>
                 ${feature.properties.short_description
                     ? html`
-                          <p>${feature.properties.short_description}</p>
+                          <p>${html([feature.properties.short_description])}</p>
                       `
                     : ""}
             </div>


### PR DESCRIPTION
Remove 100vh in toolbar-options
Render html in landmark tooltip content.